### PR TITLE
fix: use WorkingDirectory expr in ecnu_login.service.template

### DIFF
--- a/ecnu_login.service.template
+++ b/ecnu_login.service.template
@@ -3,7 +3,7 @@ Description=login into ecnu network
 
 [Service]
 Type=oneshot
-WorkingDirectory=${wd}
+WorkingDirectory=$PWD
 ExecStart=sh ./ecnu_login.sh
 User=${USER}
 StandardOutput=journal


### PR DESCRIPTION
We should use `$PWD` rather than `${wd}` to get current working directory, the later one will be substituted with empty string.